### PR TITLE
Fix Regional Cache Files Filtering

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -3895,9 +3895,9 @@ namespace BetterHI3Launcher
 											sub_lines[at_line] = line.Replace(" ,", ",");
 											LogLine();
 										}
-										if(line.Contains("	"))
+										if(line.Contains("  "))
 										{
-											sub_lines[at_line] = line.Replace("	 ", " ");
+											sub_lines[at_line] = line.Replace("  ", " ");
 											LogLine();
 										}
 										if(at_line + 1 < line_count && string.IsNullOrEmpty(sub_lines[at_line + 1]))

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -2287,12 +2287,12 @@ namespace BetterHI3Launcher
 		 * CS	-> Size of the file
 		 */
 		private class CacheDataProperties
-        {
+		{
 			public string N { get; set; }
 			public string CRC { get; set; }
 			public long CS { get; set; }
 			public CacheType Type { get; set; }
-        }
+		}
 
 		/* Filter Region Type of Cache File
 		 * 0 -> the file is a regional file but outside user region.
@@ -2400,7 +2400,7 @@ namespace BetterHI3Launcher
 					FileInfo fileInfo;
 
 					for (int i = 0; i < CacheFiles.Count; i++)
-                    {
+					{
 						name = $"{NormalizePath(CacheFiles[i].N)}.unity3d";
 						size = CacheFiles[i].CS;
 						md5 = CacheFiles[i].CRC;
@@ -2409,7 +2409,7 @@ namespace BetterHI3Launcher
 						// Combine Path and assign their own path
 						// If none of them assigned as Unknown type, throw an exception.
 						switch (cacheType)
-                        {
+						{
 							default:
 								throw new Exception("Unknown cache file data type");
 							case CacheType.Data:
@@ -2480,7 +2480,7 @@ namespace BetterHI3Launcher
 				{
 					Log($"Finished verifying files, found corrupted/missing files: {BadFiles.Count}");
 					if (new DialogWindow(App.TextStrings["contextmenu_download_cache"], string.Format(App.TextStrings["msgbox_repair_3_msg"], BadFiles.Count, BpUtility.ToBytesCount(bad_files_size)), DialogWindow.DialogType.Question).ShowDialog() == true)
-                    {
+					{
 						string url, data_type = string.Empty, path = string.Empty;
 						string server = Server == 0 ? "global" : "os";
 
@@ -2490,10 +2490,10 @@ namespace BetterHI3Launcher
 						await Task.Run(async () =>
 						{
 							for (int i = 0; i < BadFiles.Count; i++)
-                            {
+							{
 								switch (BadFiles[i].Type)
-                                {
-                                    case CacheType.Data:
+								{
+									case CacheType.Data:
 										data_type = "data";
 										path = Path.Combine(GameCachePath, "Data", NormalizePath(BadFiles[i].N) + ".unity3d");
 										break;
@@ -2517,8 +2517,8 @@ namespace BetterHI3Launcher
 									TaskbarItemInfo.ProgressValue = progress;
 								});
 
-                                try
-                                {
+								try
+								{
 									BpWebClient web_client = new BpWebClient();
 
 									if (!Directory.Exists(Path.GetDirectoryName(path)))
@@ -3895,9 +3895,9 @@ namespace BetterHI3Launcher
 											sub_lines[at_line] = line.Replace(" ,", ",");
 											LogLine();
 										}
-										if(line.Contains("  "))
+										if(line.Contains("	"))
 										{
-											sub_lines[at_line] = line.Replace("  ", " ");
+											sub_lines[at_line] = line.Replace("	 ", " ");
 											LogLine();
 										}
 										if(at_line + 1 < line_count && string.IsNullOrEmpty(sub_lines[at_line + 1]))

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -2316,7 +2316,9 @@ namespace BetterHI3Launcher
 
 		private async void DownloadGameCacheHi3Mirror(string game_language)
 		{
-			string data;
+			string data,
+				preformatAPIUrl = OnlineVersionInfo.game_info.mirror.hi3mirror.api.ToString(),
+				preformatDataUrl = OnlineVersionInfo.game_info.mirror.hi3mirror.game_cache.ToString();
 			List<CacheDataProperties> CacheFiles, BadFiles;
 			CacheType cacheType;
 			try
@@ -2352,7 +2354,7 @@ namespace BetterHI3Launcher
 						}
 
 						// Get URL and API data
-						string url = string.Format(OnlineVersionInfo.game_info.mirror.hi3mirror.api.ToString(), i, server);
+						string url = string.Format(preformatAPIUrl, i, server);
 						data = web_client.DownloadString(url);
 
 						// Do Elimination Process
@@ -2507,7 +2509,7 @@ namespace BetterHI3Launcher
 										break;
 								}
 
-								url = string.Format(OnlineVersionInfo.game_info.mirror.hi3mirror.game_cache.ToString(), server, data_type, BadFiles[i].N);
+								url = string.Format(preformatDataUrl, server, data_type, BadFiles[i].N);
 
 								Dispatcher.Invoke(() =>
 								{

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -2482,7 +2482,7 @@ namespace BetterHI3Launcher
 					if (new DialogWindow(App.TextStrings["contextmenu_download_cache"], string.Format(App.TextStrings["msgbox_repair_3_msg"], BadFiles.Count, BpUtility.ToBytesCount(bad_files_size)), DialogWindow.DialogType.Question).ShowDialog() == true)
 					{
 						string url, data_type = string.Empty, path = string.Empty;
-						string server = Server == 0 ? "global" : "os";
+						string server = Server == 0 ? "global" : "sea";
 
 						int downloaded_files = 0;
 						Status = LauncherStatus.Downloading;

--- a/Utility.cs
+++ b/Utility.cs
@@ -64,9 +64,6 @@ namespace BetterHI3Launcher
 			}
 		}
 
-		public static string CreateMD5(Stream fs) => BytesToHex(MD5.Create().ComputeHash(fs));
-		public static string BytesToHex(in byte[] bytes) => BitConverter.ToString(bytes).Replace("-", string.Empty);
-
 		// https://stackoverflow.com/a/49535675/7570821
 		public static string ToBytesCount(long bytes)
 		{

--- a/Utility.cs
+++ b/Utility.cs
@@ -64,6 +64,9 @@ namespace BetterHI3Launcher
 			}
 		}
 
+		public static string CreateMD5(Stream fs) => BytesToHex(MD5.Create().ComputeHash(fs));
+		public static string BytesToHex(in byte[] bytes) => BitConverter.ToString(bytes).Replace("-", string.Empty);
+
 		// https://stackoverflow.com/a/49535675/7570821
 		public static string ToBytesCount(long bytes)
 		{


### PR DESCRIPTION
This changes will bring a fix while filtering regional cache file and prevents non-regional cache files with similar ``_<lang>`` prefix to be filtered.

This changes will also simplify filtering mechanism using ``FilterRegion()`` method